### PR TITLE
Enable strict mode

### DIFF
--- a/lib/node-ifttt-maker.js
+++ b/lib/node-ifttt-maker.js
@@ -1,3 +1,4 @@
+"use strict";
 /*
  * node-ifttt-maker
  * https://github.com/j3lte/node-ifttt-maker


### PR DESCRIPTION
Thank you for this great library 👍 I found it works great on recent versions of node, on older ones I get this error:

```
Block-scoped declarations (let, const, function, class) not yet supported outside strict mode.
```